### PR TITLE
Add static analysis support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,36 @@ TARGET_LINK_LIBRARIES(LRSpline ${DEPLIBS})
 SET_TARGET_PROPERTIES(LRSpline PROPERTIES  VERSION ${LRSpline_VERSION}
                       SOVERSION ${LRSpline_VERSION_MAJOR}.${LRSpline_VERSION_MINOR})
 
+# Add static analysis tests
+configure_file(test/clang-check-test.sh.in bin/clang-check-test.sh @ONLY)
+configure_file(test/cppcheck-test.sh.in bin/cppcheck-test.sh @ONLY)
+find_program(CLANGCHECK_COMMAND clang-check)
+find_program(CPPCHECK_COMMAND cppcheck)
+if(CPPCHECK_COMMAND)
+  foreach(include ${INCLUDES})
+    list(APPEND IPATH -I ${include})
+  endforeach()
+endif()
+foreach(src ${LRSPLINE_SRCS})
+  get_filename_component(name ${src} NAME)
+  get_filename_component(EXT ${src} EXT)
+  if(EXT STREQUAL .cpp)
+    if(NOT IS_ABSOLUTE ${src})
+      set(src ${PROJECT_SOURCE_DIR}/${src})
+    endif()
+    if(CLANGCHECK_COMMAND AND CMAKE_EXPORT_COMPILE_COMMANDS)
+      add_test(NAME clang-check+${name}
+               COMMAND bin/clang-check-test.sh ${CLANGCHECK_COMMAND} ${src}
+               CONFIGURATIONS analyze clang-check)
+    endif()
+    if(CPPCHECK_COMMAND)
+      add_test(NAME cppcheck+${name}
+               COMMAND bin/cppcheck-test.sh ${CPPCHECK_COMMAND} ${src} ${IPATHS}
+               CONFIGURATIONS analyze cppcheck)
+    endif()
+  endif()
+endforeach()
+
 # Make some Apps
 ADD_EXECUTABLE(reduceContinuity ${PROJECT_SOURCE_DIR}/Apps/reduceContinuity.cpp)
 TARGET_LINK_LIBRARIES(reduceContinuity LRSpline ${DEPLIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,8 @@ INCLUDE(cmake/Modules/UseMultiArch.cmake)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
-IF(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+IF(CMAKE_CXX_COMPILER_ID MATCHES GNU OR
+   CMAKE_CXX_COMPILER_ID MATCHES Clang)
 # check if compiler supports c++-0x
   CHECK_CXX_COMPILER_FLAG("-std=gnu++0x" HAVE_0x)
   IF(HAVE_0x)
@@ -36,7 +37,7 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES GNU)
     MESSAGE("A compiler with c++-0x support is needed")
     EXIT(1)
   ENDIF(HAVE_0x)
-ENDIF(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+ENDIF()
 
 # Check that the required C++11 features are available
 CHECK_CXX_SOURCE_COMPILES("

--- a/test/clang-check-test.sh.in
+++ b/test/clang-check-test.sh.in
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script performs a single analysis using clang-check
+# It is used by the 'make test' target in the buildsystems
+# Usually you should use 'ctest -C clang-check' rather than calling this script directly
+#
+# Parameters: $1 = Application binary
+#             $2 = Source file to process
+
+clangcheck_cmd=$1
+source_file=$2
+
+tmpfil=`mktemp`
+$clangcheck_cmd -p @CMAKE_BINARY_DIR@ -analyze $source_file &> $tmpfil
+cat $tmpfil
+if test -s $tmpfil
+then
+  rm $tmpfil
+  exit 1
+fi
+
+rm $tmpfil
+exit 0

--- a/test/cppcheck-test.sh.in
+++ b/test/cppcheck-test.sh.in
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script performs a single analysis using cppcheck
+# It is used by the 'make test' target in the buildsystems
+# Usually you should use 'ctest -C cppcheck' rather than calling this script directly
+#
+# Parameters: $1 = Application binary
+#             $2 = Source file to process
+#             $3..$N = include path parameters (-I dir1 -I dir2 ...)
+
+cppcheck_cmd=$1
+source_file=$2
+shift 2
+
+tmpfil=`mktemp`
+$cppcheck_cmd $@ --force --enable=all --suppress=unusedFunction $source_file &> $tmpfil
+nmatch=`cat $tmpfil | grep "\[.*\]" | wc -l`
+nsys=`cat $tmpfil | grep "\[/usr.*\]" | wc -l`
+nnone=`cat $tmpfil | grep "\[\\*]" | wc -l`
+let "nval=$nmatch-$nsys-$nnone"
+if test $nval -gt 0
+then
+  cat $tmpfil
+  rm $tmpfil
+  exit 1
+fi
+
+rm $tmpfil
+exit 0


### PR DESCRIPTION
This adds clang support and static analysis support to the build system.

In general: You execute the tests by
```
ctest -C analyze|cppcheck|clang-check
```
analyze configuration executes both analyzers.

To enable the clang-check based tests, it is best to build with clang since the compatiblity with gcc is only 99%. You also have to pass -DCMAKE_EXPORT_COMPILE_COMMANDS=1 when configuring.