### PR TITLE
Changes enumeration of elements and basisfunction to consistent scheme

### DIFF
--- a/Apps/TestReadWrite.cpp
+++ b/Apps/TestReadWrite.cpp
@@ -135,6 +135,9 @@ int main(int argc, char **argv) {
 	if(vol) lrv->renumberElements();
 	else    lrs->renumberElements();
 
+	if(vol) lrv->renumberBasisfunctions();
+	else    lrs->renumberBasisfunctions();
+
 	// test writing to file
 	ofstream lrfile;
 	lrfile.open("TestReadWrite.lr");

--- a/Apps/TestReadWrite.cpp
+++ b/Apps/TestReadWrite.cpp
@@ -132,6 +132,9 @@ int main(int argc, char **argv) {
 		inputfile >> *lrs;
 	}
 
+	if(vol) lrv->renumberElements();
+	else    lrs->renumberElements();
+
 	// test writing to file
 	ofstream lrfile;
 	lrfile.open("TestReadWrite.lr");

--- a/include/LRSpline/Basisfunction.h
+++ b/include/LRSpline/Basisfunction.h
@@ -151,6 +151,7 @@ public:
 	// operator overloading
 	bool equals(const Basisfunction &other) const ;
 	bool operator==(const Basisfunction &other) const;
+	bool operator<( const Basisfunction &other) const;
 	void operator+=(const Basisfunction &other) ;
 	std::vector<double>&       operator[](int i)       { return knots_[i]; } ;
 	const std::vector<double>& operator[](int i) const { return knots_[i]; } ;

--- a/include/LRSpline/Element.h
+++ b/include/LRSpline/Element.h
@@ -88,6 +88,8 @@ public:
 	virtual void read(std::istream &is);
 	virtual void write(std::ostream &os) const;
 
+	bool operator<(const Element &other) const;
+
 private:
 	std::vector<double> min;  // lower left corner in typical 2 or 3 dimensions
 	std::vector<double> max;  // upper right corner

--- a/include/LRSpline/LRSpline.h
+++ b/include/LRSpline/LRSpline.h
@@ -47,6 +47,8 @@ public:
 
 	virtual void generateIDs() const;
 
+	virtual void renumberElements() ;
+
 	// common get methods
 
 	//! \brief returns the number of B-splines (basisfunctions) in this LR-spline object

--- a/include/LRSpline/LRSpline.h
+++ b/include/LRSpline/LRSpline.h
@@ -48,6 +48,7 @@ public:
 	virtual void generateIDs() const;
 
 	virtual void renumberElements() ;
+	virtual void renumberBasisfunctions() ;
 
 	// common get methods
 
@@ -93,22 +94,8 @@ public:
 	// traditional get methods
 	Element* getElement(int i)                                     { return element_[i]; };
 	const Element* getElement(int i) const                         { return element_[i]; };
-	Basisfunction* getBasisfunction(int iBasis) {
-		if(iBasis<0 || iBasis>=basis_.size())
-			return NULL;
-		HashSet_iterator<Basisfunction*> it=basis_.begin();
-		for(int i=0; i<iBasis; i++)
-			++it;
-		return *it;
-	}
-	const Basisfunction* getBasisfunction(int iBasis) const {
-		if(iBasis<0 || iBasis>=basis_.size())
-			return NULL;
-		HashSet_const_iterator<Basisfunction*> it=basis_.begin();
-		for(int i=0; i<iBasis; i++)
-			++it;
-		return *it;
-	}
+	Basisfunction* getBasisfunction(int iBasis);
+	const Basisfunction* getBasisfunction(int iBasis) const ;
 
 	// refinement functions
 	virtual void refineBasisFunction(int index) = 0;

--- a/src/Basisfunction.cpp
+++ b/src/Basisfunction.cpp
@@ -643,6 +643,21 @@ bool Basisfunction::operator==(const Basisfunction &other) const {
 }
 
 /************************************************************************************************************************//**
+ * \brief Test for B-spline ordering according to geometric factor instead of hash function
+ * \param other The other B-spline to check against
+ * \returns True if this.knot[i][j] < other.knot[i][j] for the smallest possible (i,j) whith different values
+ ***************************************************************************************************************************/
+bool Basisfunction::operator<(const Basisfunction &other) const {
+	for(uint i=0; i<knots_.size(); i++)
+		for(uint j=0; j<knots_[i].size(); j++)
+			if(     knots_[i][j] > other[i][j]) return false;
+			else if(knots_[i][j] < other[i][j]) return true;
+			// else continue;
+
+	return false; // all knot vectors identical
+}
+
+/************************************************************************************************************************//**
  * \brief Test for B-spline equality
  * \param other The other B-spline to check against
  * \returns True if the knot vectors are identical (up to a tolerance of 1e-10)

--- a/src/Element.cpp
+++ b/src/Element.cpp
@@ -236,6 +236,18 @@ bool Element::isOverloaded()  const {
 		}
 	}
 	return false;
+
+}
+
+bool Element::operator<(const Element &other) const {
+	for(size_t i=0; i<min.size(); i++) {
+		if(this->min[i] > other.getParmin(i))
+			return false;
+		else if(this->min[i] < other.getParmin(i))
+			return true;
+		// else(this->min[i] == other.getParmin(i)) continue
+	}
+	return false;
 }
 
 } // end namespace LR

--- a/src/LRSpline.cpp
+++ b/src/LRSpline.cpp
@@ -11,6 +11,14 @@ LRSpline::LRSpline() {
 	element_.resize(0);
 }
 
+bool compare(const Element* a, const Element* b) {return *a < *b;};
+
+void LRSpline::renumberElements() {
+    std::sort(element_.begin(), element_.end(), compare);
+	for(size_t i=0; i<element_.size(); i++)
+		element_[i]->setId(i);
+}
+
 void LRSpline::generateIDs() const {
 	uint i=0;
 	for(Basisfunction *b : basis_)

--- a/src/LRSpline.cpp
+++ b/src/LRSpline.cpp
@@ -11,19 +11,40 @@ LRSpline::LRSpline() {
 	element_.resize(0);
 }
 
-bool compare(const Element* a, const Element* b) {return *a < *b;};
+bool compareEl(const Element* a, const Element* b) {return *a < *b;};
 
 void LRSpline::renumberElements() {
-    std::sort(element_.begin(), element_.end(), compare);
+	this->generateIDs();
+	std::sort(element_.begin(), element_.end(), compareEl);
 	for(size_t i=0; i<element_.size(); i++)
 		element_[i]->setId(i);
 }
 
+bool compareFunc(const Basisfunction* a, const Basisfunction* b) {return *a < *b;};
+
+void LRSpline::renumberBasisfunctions() {
+	std::vector<Basisfunction*> tmp(basis_.size());
+	std::copy(basis_.begin(), basis_.end(), tmp.begin());
+	std::sort(tmp.begin(), tmp.end(), compareFunc);
+	for(size_t i=0; i<tmp.size(); i++)
+		tmp[i]->setId(i);
+}
+
 void LRSpline::generateIDs() const {
+	/* enumeration by hash function (old way), sensitive to scaling and bit precision
 	uint i=0;
 	for(Basisfunction *b : basis_)
 		b->setId(i++);
-	for(i=0; i<element_.size(); i++)
+	*/
+
+	/* enumeartion by geometric sorting (priorizing lower left corner) */
+	std::vector<Basisfunction*> tmp(basis_.size());
+	std::copy(basis_.begin(), basis_.end(), tmp.begin());
+	std::sort(tmp.begin(), tmp.end(), compareFunc);
+	for(size_t i=0; i<tmp.size(); i++)
+		tmp[i]->setId(i);
+
+	for(size_t i=0; i<element_.size(); i++)
 		element_[i]->setId(i);
 }
 
@@ -104,6 +125,20 @@ void LRSpline::rebuildDimension(int dimvalue) {
 	for(Basisfunction *b : basis_)
 		b->setDimension(dimvalue);
 	dim_ = dimvalue;
+}
+
+Basisfunction* LRSpline::getBasisfunction(int iBasis) {
+	if(iBasis<0 || iBasis>=basis_.size()) return NULL;
+	for(auto b : basis_)
+		if(b->getId() == iBasis) return b;
+	return NULL;
+}
+
+const Basisfunction* LRSpline::getBasisfunction(int iBasis) const {
+	if(iBasis<0 || iBasis>=basis_.size()) return NULL;
+	for(auto b : basis_)
+		if(b->getId() == iBasis) return b;
+	return NULL;
 }
 
 


### PR DESCRIPTION
The element reordering as it stands is currently optional, but the basisfunction reordering is forced. This is because any call to `LRSpline::generateIDs()` will overwrite the  enumeration given by `LRSpline::renumberBasisfunctions()`. `generateIDs()` is frequently called, for instance during write-to-file, so I couldn't find a good way around this. Let me know if you have any suggestions.

Hopefully this will not break any downstream applications such as IFEM, but it is not unthinkable that it is going to since the new enumeration scheme is forced.